### PR TITLE
feat!: store vrs coords

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,25 @@ See the [vrsix Terra workflow](https://github.com/gks-anvil/vrsix-workflow) for 
 
 ## Usage
 
-From a VCF, ingest a VRS ID and the corresponding VCF-called location (i.e. sufficient inputs for a tabix lookup), and store them in a sqlite database.
+To get started, you will need a fully VRS-annotated VCF. Confirm that your VCF contains the following info fields:
+- VRS_Allele_IDs
+- VRS_Starts
+- VRS_Stops
+- VRS_States
+
+For example, confirm that `chr1.vcf` has the required fields.
+
+```bash
+bcftools view -h chr1.vcf | grep '^##INFO='
+```
+
+From a VRSified VCF, ingest a VRS ID and the corresponding VCF-called location (i.e. sufficient inputs for a tabix lookup), and store them in a sqlite database.
 
 ```shell
 vrsix load chr1.vcf
 ```
 
-All instances of variations are stored with an associated file URI to support later retrieval. By default, this URI is simply the input VCF's location in the file system, but you may declare a custom URI instead as an optional argument:
+Each variation is stored with an associated file URI to support later retrieval. By default, this URI is simply the input VCF's location in the file system, but you may declare a custom URI instead as an optional argument:
 
 ```shell
 vrsix load chr1.vcf gs://my_stuff/chr1.vcf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vrsix"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     {name = "James Stevenson"},
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,3 +16,4 @@ tokio = { version = "1.40.0", features = ["full"] }
 pyo3 = { version = "0.23.4", features = ["abi3-py310", "experimental-async"]}
 log = "0.4.22"
 tempfile = "3.14.0"
+itertools = "0.14.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::{create_exception, exceptions, prelude::*, Python};
 pub mod load;
+pub mod parse;
 pub mod sqlite;
 use std::path::PathBuf;
 use tokio::runtime::Runtime;

--- a/rust/src/load.rs
+++ b/rust/src/load.rs
@@ -1,4 +1,4 @@
-use crate::parse::{cast_string_array_to_int, get_info_field, VrsVcfField};
+use crate::parse::{get_int_info_field, get_str_info_field, VrsVcfField};
 use crate::sqlite::{get_db_connection, setup_db, DbRow};
 use crate::{FiletypeError, SqliteFileError, VrsixDbError};
 use futures::TryStreamExt;
@@ -123,18 +123,10 @@ pub async fn load_vcf(vcf_path: PathBuf, db_url: &str, uri: String) -> PyResult<
         .map_err(|e| VrsixDbError::new_err(format!("Failed to insert file URI `{uri}`: {e}")))?;
 
     while let Some(record) = records.try_next().await? {
-        let vrs_ids = get_info_field(record.info(), &header, VrsVcfField::VrsAlleleIds)?;
-        let vrs_starts = cast_string_array_to_int(get_info_field(
-            record.info(),
-            &header,
-            VrsVcfField::VrsStarts,
-        )?)?;
-        let vrs_ends = cast_string_array_to_int(get_info_field(
-            record.info(),
-            &header,
-            VrsVcfField::VrsEnds,
-        )?)?;
-        let vrs_states = get_info_field(record.info(), &header, VrsVcfField::VrsStates)?;
+        let vrs_ids = get_str_info_field(record.info(), &header, VrsVcfField::VrsAlleleIds)?;
+        let vrs_starts = get_int_info_field(record.info(), &header, VrsVcfField::VrsStarts)?;
+        let vrs_ends = get_int_info_field(record.info(), &header, VrsVcfField::VrsEnds)?;
+        let vrs_states = get_str_info_field(record.info(), &header, VrsVcfField::VrsStates)?;
         let chrom = record.reference_sequence_name();
         let pos = record.variant_start().unwrap()?.get();
 

--- a/rust/src/load.rs
+++ b/rust/src/load.rs
@@ -1,13 +1,11 @@
+use crate::parse::{cast_string_array_to_int, get_info_field, VrsVcfField};
 use crate::sqlite::{get_db_connection, setup_db, DbRow};
-use crate::{FiletypeError, SqliteFileError, VcfError, VrsixDbError};
+use crate::{FiletypeError, SqliteFileError, VrsixDbError};
 use futures::TryStreamExt;
+use itertools::izip;
 use log::{error, info};
 use noodles_bgzf::r#async::Reader as BgzfReader;
-use noodles_vcf::{
-    self as vcf,
-    r#async::io::Reader as VcfReader,
-    variant::record::info::{self, field::Value as InfoValue},
-};
+use noodles_vcf::r#async::io::Reader as VcfReader;
 use pyo3::{exceptions, prelude::*};
 use sqlx::{error::DatabaseError, sqlite::SqliteError, SqlitePool};
 use std::path::PathBuf;
@@ -20,10 +18,13 @@ use tokio::{
 async fn load_allele(db_row: DbRow, pool: &SqlitePool) -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = pool.acquire().await?;
     let result =
-        sqlx::query("INSERT INTO vrs_locations (vrs_id, chr, pos, uri_id) VALUES (?, ?, ?, ?);")
+        sqlx::query("INSERT INTO vrs_locations (vrs_id, chr, pos, vrs_start, vrs_end, vrs_state, uri_id) VALUES (?, ?, ?, ?, ?, ?, ?);")
             .bind(db_row.vrs_id)
             .bind(db_row.chr)
             .bind(db_row.pos)
+            .bind(db_row.vrs_start)
+            .bind(db_row.vrs_end)
+            .bind(db_row.vrs_state)
             .bind(db_row.uri_id)
             .execute(&mut *conn)
             .await;
@@ -43,27 +44,6 @@ async fn load_allele(db_row: DbRow, pool: &SqlitePool) -> Result<(), Box<dyn std
         return Err(err.into());
     }
     Ok(())
-}
-
-fn get_vrs_ids(info: vcf::record::Info, header: &vcf::Header) -> Result<Vec<String>, PyErr> {
-    if let Some(Ok(Some(InfoValue::Array(array)))) = info.get(header, "VRS_Allele_IDs") {
-        if let info::field::value::Array::String(array_elements) = array {
-            let vec = array_elements
-                .iter()
-                .map(|cow_str| cow_str.unwrap().unwrap_or_default().to_string())
-                .collect();
-            return Ok(vec);
-        } else {
-            error!("Unable to unpack `{:?}` as an array of values", array);
-            Err(VcfError::new_err("expected string array variant"))
-        }
-    } else {
-        error!(
-            "Unable to unpack VRS_Allele_IDs from info fields: {:?}. Are annotations available?",
-            info
-        );
-        Err(VcfError::new_err("Expected Array variant"))
-    }
 }
 
 async fn get_reader(
@@ -143,11 +123,24 @@ pub async fn load_vcf(vcf_path: PathBuf, db_url: &str, uri: String) -> PyResult<
         .map_err(|e| VrsixDbError::new_err(format!("Failed to insert file URI `{uri}`: {e}")))?;
 
     while let Some(record) = records.try_next().await? {
-        let vrs_ids = get_vrs_ids(record.info(), &header)?;
+        let vrs_ids = get_info_field(record.info(), &header, VrsVcfField::VrsAlleleIds)?;
+        let vrs_starts = cast_string_array_to_int(get_info_field(
+            record.info(),
+            &header,
+            VrsVcfField::VrsStarts,
+        )?)?;
+        let vrs_ends = cast_string_array_to_int(get_info_field(
+            record.info(),
+            &header,
+            VrsVcfField::VrsEnds,
+        )?)?;
+        let vrs_states = get_info_field(record.info(), &header, VrsVcfField::VrsStates)?;
         let chrom = record.reference_sequence_name();
         let pos = record.variant_start().unwrap()?.get();
 
-        for vrs_id in vrs_ids {
+        for (vrs_id, vrs_start, vrs_end, vrs_state) in
+            izip!(vrs_ids, vrs_starts, vrs_ends, vrs_states)
+        {
             let row = DbRow {
                 vrs_id: vrs_id
                     .strip_prefix("ga4gh:VA.")
@@ -155,6 +148,9 @@ pub async fn load_vcf(vcf_path: PathBuf, db_url: &str, uri: String) -> PyResult<
                     .to_string(),
                 chr: chrom.to_string(),
                 pos: pos.try_into().unwrap(),
+                vrs_start,
+                vrs_end,
+                vrs_state,
                 uri_id,
             };
             load_allele(row, &db_pool).await.map_err(|e| {

--- a/rust/src/parse.rs
+++ b/rust/src/parse.rs
@@ -141,38 +141,3 @@ pub fn get_int_info_field(
         Err(VcfError::new_err("Expected Array variant"))
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use noodles_vcf::{
-        self as vcf,
-        header::record::value::{map::Info, Map},
-        header::FileFormat,
-    };
-
-    #[test]
-    fn test_get_info_field() {
-        pub const IDS_KEY: &str = "VRS_Allele_IDs";
-        let ids_id = IDS_KEY;
-        let ids_info = Map::<Info>::from(ids_id);
-        pub const STARTS_KEY: &str = "VRS_Starts";
-        let starts_id = STARTS_KEY;
-        let starts_info = Map::<Info>::from(starts_id);
-        pub const ENDS_KEY: &str = "VRS_Ends";
-        let ends_id = ENDS_KEY;
-        let ends_info = Map::<Info>::from(ends_id);
-        pub const STATES_KEY: &str = "VRS_States";
-        let states_id = STATES_KEY;
-        let states_info = Map::<Info>::from(states_id);
-
-        let header = vcf::Header::builder()
-            .set_file_format(FileFormat::default())
-            .add_info(ids_id, ids_info.clone())
-            .add_info(starts_id, starts_info.clone())
-            .add_info(ends_id, ends_info.clone())
-            .add_info(states_id, states_info.clone())
-            .build();
-        let _infos = header.infos();
-        // TODO finish this
-    }
-}

--- a/rust/src/parse.rs
+++ b/rust/src/parse.rs
@@ -1,0 +1,99 @@
+use log::error;
+
+use crate::VcfError;
+use noodles_vcf::{
+    self as vcf,
+    variant::record::info::{self, field::Value as InfoValue},
+};
+use pyo3::prelude::*;
+
+pub enum VrsVcfField {
+    VrsAlleleIds,
+    VrsStarts,
+    VrsEnds,
+    VrsStates,
+}
+
+impl VrsVcfField {
+    fn as_str(&self) -> &'static str {
+        match self {
+            VrsVcfField::VrsAlleleIds => "VRS_Allele_IDs",
+            VrsVcfField::VrsStarts => "VRS_Starts",
+            VrsVcfField::VrsEnds => "VRS_Ends",
+            VrsVcfField::VrsStates => "VRS_States",
+        }
+    }
+}
+
+/// Retrieve data from INFO fields
+/// Would prefer there was a way to do this in one pass instead of calling the method repeatedly
+pub fn get_info_field(
+    info: vcf::record::Info,
+    header: &vcf::Header,
+    field: VrsVcfField,
+) -> Result<Vec<String>, PyErr> {
+    if let Some(Ok(Some(InfoValue::Array(ids_array)))) = info.get(header, field.as_str()) {
+        if let info::field::value::Array::String(array_elements) = ids_array {
+            let vec = array_elements
+                .iter()
+                .map(|cow_str| cow_str.unwrap().unwrap_or_default().to_string())
+                .collect();
+            return Ok(vec);
+        } else {
+            error!("Unable to unpack `{:?}` as an array of values", ids_array);
+            Err(VcfError::new_err("expected string array variant"))
+        }
+    } else {
+        error!(
+            "Unable to unpack {:?} from info fields: {:?}. Are annotations available?",
+            field.as_str(),
+            info
+        );
+        Err(VcfError::new_err("Expected Array variant"))
+    }
+}
+
+pub fn cast_string_array_to_int(info_field_array: Vec<String>) -> Result<Vec<i32>, PyErr> {
+    info_field_array
+        .into_iter()
+        .map(|s| {
+            s.parse::<i32>()
+                .map_err(|_e| VcfError::new_err("Unable to cast String instance to i32"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use noodles_vcf::{
+        self as vcf,
+        header::record::value::{map::Info, Map},
+        header::FileFormat,
+    };
+
+    #[test]
+    fn test_get_info_field() {
+        pub const IDS_KEY: &str = "VRS_Allele_IDs";
+        let ids_id = IDS_KEY;
+        let ids_info = Map::<Info>::from(ids_id);
+        pub const STARTS_KEY: &str = "VRS_Starts";
+        let starts_id = STARTS_KEY;
+        let starts_info = Map::<Info>::from(starts_id);
+        pub const ENDS_KEY: &str = "VRS_Ends";
+        let ends_id = ENDS_KEY;
+        let ends_info = Map::<Info>::from(ends_id);
+        pub const STATES_KEY: &str = "VRS_States";
+        let states_id = STATES_KEY;
+        let states_info = Map::<Info>::from(states_id);
+
+        let header = vcf::Header::builder()
+            .set_file_format(FileFormat::default())
+            .add_info(ids_id, ids_info.clone())
+            .add_info(starts_id, starts_info.clone())
+            .add_info(ends_id, ends_info.clone())
+            .add_info(states_id, states_info.clone())
+            .build();
+        let _infos = header.infos();
+        // TODO finish this
+    }
+}

--- a/rust/src/parse.rs
+++ b/rust/src/parse.rs
@@ -7,6 +7,7 @@ use noodles_vcf::{
 };
 use pyo3::prelude::*;
 
+#[derive(Debug)]
 pub enum VrsVcfField {
     VrsAlleleIds,
     VrsStarts,
@@ -25,9 +26,31 @@ impl VrsVcfField {
     }
 }
 
-/// Retrieve data from INFO fields
-/// Would prefer there was a way to do this in one pass instead of calling the method repeatedly
-pub fn get_info_field(
+/// Extracts an array of strings from a VCF record's info field.
+///
+/// This function attempts to retrieve the info field specified by `field` from the given VCF record info
+/// using the provided `header`. It expects the field to be an array of strings, and if successful,
+/// returns a vector of `String` values. If the field is not found, not an array, or is not stored as strings,
+/// an error is returned.
+///
+/// # Arguments
+///
+/// * `info` - The VCF record info object.
+/// * `header` - A reference to the VCF header used to interpret the info field.
+/// * `field` - The field identifier as a `VrsVcfField`.
+///
+/// # Returns
+///
+/// A `Result` containing a vector of strings if the info field is successfully extracted and converted;
+/// otherwise, returns a `PyErr`.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The specified field is not present in the info.
+/// - The field is present but not stored as an array of strings.
+/// - The array variant does not match the expected type.
+pub fn get_str_info_field(
     info: vcf::record::Info,
     header: &vcf::Header,
     field: VrsVcfField,
@@ -53,14 +76,70 @@ pub fn get_info_field(
     }
 }
 
-pub fn cast_string_array_to_int(info_field_array: Vec<String>) -> Result<Vec<i32>, PyErr> {
-    info_field_array
-        .into_iter()
-        .map(|s| {
-            s.parse::<i32>()
-                .map_err(|_e| VcfError::new_err("Unable to cast String instance to i32"))
-        })
-        .collect()
+/// Extracts an integer array from a VCF record's info field.
+///
+/// This function attempts to retrieve the info field specified by `field` from the VCF record `info`
+/// using the provided `header`. It expects the field to be an array stored either as integers or as strings.
+///
+/// - If the array is stored as integers, the function unwraps each element and returns a `Vec<i32>`.
+/// - If the array is stored as strings, each string is parsed into an `i32`.
+///
+/// The VRS-Python annotator now processes numeric annotation fields as Integers, but it didn't
+/// always, so the fallback is there to manage legacy VCF outputs.
+///
+/// # Arguments
+///
+/// * `info` - The VCF record info object.
+/// * `header` - A reference to the VCF header, which is used to interpret the info field.
+/// * `field` - The field identifier as a `VrsVcfField`.
+///
+/// # Returns
+///
+/// Returns `Ok(Vec<i32>)` if the info field is successfully extracted and parsed. Otherwise, an error is returned:
+/// - If the field is not present or not an array.
+/// - If the array is not in an expected format (i.e. neither integer nor string array).
+/// - If parsing a string into an integer fails.
+///
+/// # Errors
+///
+/// This function returns a `PyErr` if the expected array variant is not found or if any parsing error occurs.
+pub fn get_int_info_field(
+    info: vcf::record::Info,
+    header: &vcf::Header,
+    field: VrsVcfField,
+) -> Result<Vec<i32>, PyErr> {
+    if let Some(Ok(Some(InfoValue::Array(ids_array)))) = info.get(header, field.as_str()) {
+        if let info::field::value::Array::Integer(array_elements) = ids_array {
+            let vec = array_elements
+                .iter()
+                .map(|i| i.unwrap().unwrap_or_default())
+                .collect();
+            return Ok(vec);
+        } else {
+            if let info::field::value::Array::String(array_elements) = ids_array {
+                let vec = array_elements
+                    .iter()
+                    .map(|cow_str| cow_str.unwrap().unwrap_or_default().to_string())
+                    .map(|s| {
+                        s.parse::<i32>()
+                            .map_err(|_e| VcfError::new_err("Unable to parse int"))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                return Ok(vec);
+            }
+            error!("Unable to unpack `{:?}` as an array of values", ids_array);
+            Err(VcfError::new_err(
+                "Expected array variable of strings or integers",
+            ))
+        }
+    } else {
+        error!(
+            "Unable to unpack {:?} from info fields: {:?}. Are annotations available?",
+            field.as_str(),
+            info
+        );
+        Err(VcfError::new_err("Expected Array variant"))
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/sqlite.rs
+++ b/rust/src/sqlite.rs
@@ -31,6 +31,9 @@ pub async fn setup_db(db_url: &str) -> Result<(), Error> {
             vrs_id TEXT NOT NULL,
             chr TEXT NOT NULL,
             pos INTEGER NOT NULL,
+            vrs_start INTEGER NOT NULL,
+            vrs_end INTEGER NOT NULL,
+            vrs_state TEXT NOT NULL,
             uri_id INTEGER NOT NULL,
             FOREIGN KEY (uri_id) REFERENCES file_uris(id),
             UNIQUE(vrs_id, chr, pos, uri_id)
@@ -84,6 +87,9 @@ pub struct DbRow {
     pub vrs_id: String,
     pub chr: String,
     pub pos: i64,
+    pub vrs_start: i32,
+    pub vrs_end: i32,
+    pub vrs_state: String,
     pub uri_id: i64,
 }
 

--- a/tests/fixtures/input_positions_ints.vcf
+++ b/tests/fixtures/input_positions_ints.vcf
@@ -1,0 +1,241 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20160824
+##CL=vcffilter -i - -o - --javascript "function record() {HG001.PS=\".\";}"
+##contig=<ID=chr1,length=248956422,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr2,length=242193529,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr3,length=198295559,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr4,length=190214555,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr5,length=181538259,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr6,length=170805979,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr7,length=159345973,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr8,length=145138636,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr9,length=138394717,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr10,length=133797422,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr11,length=135086622,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr12,length=133275309,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr13,length=114364328,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14,length=107043718,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr15,length=101991189,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr16,length=90338345,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr17,length=83257441,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr18,length=80373285,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr19,length=58617616,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr20,length=64444167,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr21,length=46709983,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22,length=50818468,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrX,length=156040895,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrY,length=57227415,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrM,length=16569,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270706v1_random,length=175055,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270707v1_random,length=32032,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270708v1_random,length=127682,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270709v1_random,length=66860,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270710v1_random,length=40176,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270711v1_random,length=42210,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270712v1_random,length=176043,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270713v1_random,length=40745,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr1_KI270714v1_random,length=41717,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr2_KI270715v1_random,length=161471,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr2_KI270716v1_random,length=153799,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr3_GL000221v1_random,length=155397,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr4_GL000008v2_random,length=209709,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr5_GL000208v1_random,length=92689,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr9_KI270717v1_random,length=40062,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr9_KI270718v1_random,length=38054,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr9_KI270719v1_random,length=176845,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr9_KI270720v1_random,length=39050,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr11_KI270721v1_random,length=100316,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14_GL000009v2_random,length=201709,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14_GL000225v1_random,length=211173,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14_KI270722v1_random,length=194050,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14_GL000194v1_random,length=191469,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14_KI270723v1_random,length=38115,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14_KI270724v1_random,length=39555,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14_KI270725v1_random,length=172810,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr14_KI270726v1_random,length=43739,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr15_KI270727v1_random,length=448248,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr16_KI270728v1_random,length=1872759,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr17_GL000205v2_random,length=185591,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr17_KI270729v1_random,length=280839,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr17_KI270730v1_random,length=112551,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270731v1_random,length=150754,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270732v1_random,length=41543,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270733v1_random,length=179772,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270734v1_random,length=165050,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270735v1_random,length=42811,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270736v1_random,length=181920,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270737v1_random,length=103838,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270738v1_random,length=99375,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chr22_KI270739v1_random,length=73985,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrY_KI270740v1_random,length=37240,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270302v1,length=2274,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270304v1,length=2165,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270303v1,length=1942,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270305v1,length=1472,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270322v1,length=21476,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270320v1,length=4416,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270310v1,length=1201,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270316v1,length=1444,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270315v1,length=2276,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270312v1,length=998,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270311v1,length=12399,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270317v1,length=37690,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270412v1,length=1179,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270411v1,length=2646,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270414v1,length=2489,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270419v1,length=1029,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270418v1,length=2145,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270420v1,length=2321,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270424v1,length=2140,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270417v1,length=2043,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270422v1,length=1445,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270423v1,length=981,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270425v1,length=1884,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270429v1,length=1361,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270442v1,length=392061,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270466v1,length=1233,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270465v1,length=1774,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270467v1,length=3920,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270435v1,length=92983,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270438v1,length=112505,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270468v1,length=4055,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270510v1,length=2415,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270509v1,length=2318,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270518v1,length=2186,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270508v1,length=1951,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270516v1,length=1300,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270512v1,length=22689,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270519v1,length=138126,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270522v1,length=5674,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270511v1,length=8127,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270515v1,length=6361,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270507v1,length=5353,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270517v1,length=3253,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270529v1,length=1899,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270528v1,length=2983,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270530v1,length=2168,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270539v1,length=993,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270538v1,length=91309,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270544v1,length=1202,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270548v1,length=1599,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270583v1,length=1400,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270587v1,length=2969,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270580v1,length=1553,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270581v1,length=7046,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270579v1,length=31033,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270589v1,length=44474,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270590v1,length=4685,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270584v1,length=4513,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270582v1,length=6504,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270588v1,length=6158,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270593v1,length=3041,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270591v1,length=5796,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270330v1,length=1652,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270329v1,length=1040,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270334v1,length=1368,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270333v1,length=2699,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270335v1,length=1048,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270338v1,length=1428,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270340v1,length=1428,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270336v1,length=1026,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270337v1,length=1121,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270363v1,length=1803,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270364v1,length=2855,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270362v1,length=3530,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270366v1,length=8320,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270378v1,length=1048,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270379v1,length=1045,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270389v1,length=1298,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270390v1,length=2387,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270387v1,length=1537,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270395v1,length=1143,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270396v1,length=1880,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270388v1,length=1216,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270394v1,length=970,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270386v1,length=1788,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270391v1,length=1484,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270383v1,length=1750,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270393v1,length=1308,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270384v1,length=1658,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270392v1,length=971,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270381v1,length=1930,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270385v1,length=990,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270382v1,length=4215,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270376v1,length=1136,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270374v1,length=2656,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270372v1,length=1650,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270373v1,length=1451,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270375v1,length=2378,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270371v1,length=2805,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270448v1,length=7992,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270521v1,length=7642,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000195v1,length=182896,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000219v1,length=179198,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000220v1,length=161802,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000224v1,length=179693,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270741v1,length=157432,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000226v1,length=15008,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000213v1,length=164239,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270743v1,length=210658,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270744v1,length=168472,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270745v1,length=41891,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270746v1,length=66486,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270747v1,length=198735,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270748v1,length=93321,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270749v1,length=158759,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270750v1,length=148850,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270751v1,length=150742,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270752v1,length=27745,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270753v1,length=62944,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270754v1,length=40191,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270755v1,length=36723,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270756v1,length=79590,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270757v1,length=71251,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000214v1,length=137718,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_KI270742v1,length=186739,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000216v2,length=176608,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrUn_GL000218v1,length=161147,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##contig=<ID=chrEBV,length=171823,assembly=human_GRCh38_no_alt_analysis_set.fasta>
+##FILTER=<ID=GQlessthan70,Description="Sum of GQ for datasets with this genotype less than 70">
+##FILTER=<ID=allfilteredanddisagree,Description="All callsets have this call filtered or outside the callable regions and they have discordant genotypes or variant calls">
+##FILTER=<ID=allfilteredbutagree,Description="All callsets have this call filtered or outside the callable regions but they have the same genotype">
+##FILTER=<ID=discordantunfiltered,Description="Callsets with unfiltered calls have discordant genotypes or variant calls">
+##FILTER=<ID=discordanthet,Description="Filtered calls where a passing call is het and a high GQ but filtered call is hom var, since often the het is wrong">
+##FILTER=<ID=questionableindel,Description="Filtered calls where some callsets have a filtered indel larger than 10bp and another dataset has an implied homozygous reference call">
+##FILTER=<ID=cgonly,Description="Filtered calls where only Complete Genomics had this call and it was completely missing from any other callset">
+##FILTER=<ID=alleleimbalance,Description="Filtered calls where the net allele balance for unfiltered datasets is <0.2 or >0.8">
+##FILTER=<ID=overlappingcall,Description="Filtered sites that are within 50bp of another passing call but none of the callsets that support the 2 calls match">
+##INFO=<ID=DPSum,Number=1,Type=Integer,Description="Total read depth summed across all datasets, excluding MQ0 reads">
+##INFO=<ID=platforms,Number=1,Type=Integer,Description="Number of different platforms for which at least one callset called this genotype, whether filtered or not">
+##INFO=<ID=platformnames,Number=.,Type=String,Description="Names of platforms for which at least one callset called this genotype, whether filtered or not">
+##INFO=<ID=platformbias,Number=.,Type=String,Description="Names of platforms that have reads containing a variant at this location, but the high-confidence call is homozygous reference, indicating that there is a potential bias.">
+##INFO=<ID=datasets,Number=1,Type=Integer,Description="Number of different datasets for which at least one callset called this genotype, whether filtered or not">
+##INFO=<ID=datasetnames,Number=.,Type=String,Description="Names of datasets for which at least one callset called this genotype, whether filtered or not">
+##INFO=<ID=datasetsmissingcall,Number=.,Type=String,Description="Names of datasets that are missing a call or have an incorrect call at this location, and the high-confidence call is a variant">
+##INFO=<ID=callsets,Number=1,Type=Integer,Description="Number of different callsets that called this genotype, whether filtered or not">
+##INFO=<ID=callsetnames,Number=.,Type=String,Description="Names of callsets that called this genotype, whether filtered or not">
+##INFO=<ID=varType,Number=1,Type=String,Description="Type of variant">
+##INFO=<ID=filt,Number=.,Type=String,Description="List of callsets that had this call filtered.">
+##INFO=<ID=callable,Number=.,Type=String,Description="List of callsets that had this call in a region with low coverage of high MQ reads.">
+##INFO=<ID=difficultregion,Number=.,Type=String,Description="List of difficult region bed files containing this call.">
+##INFO=<ID=arbitrated,Number=1,Type=String,Description="TRUE if callsets had discordant calls so that arbitration was needed.">
+##INFO=<ID=callsetwiththisuniqgenopassing,Number=.,Type=String,Description="Callset that uniquely calls the PASSing genotype in GT when 2+ PASSing callsets support a different genotype.">
+##INFO=<ID=callsetwithotheruniqgenopassing,Number=.,Type=String,Description="Callset that uniquely calls a PASSing genotype different from GT when 2+ PASSing callsets support the genotype in GT.">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Total read depth summed across all datasets, excluding MQ0 reads">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Net Genotype quality across all datasets, calculated from GQ scores of callsets supporting the consensus GT, using only one callset from each dataset">
+##FORMAT=<ID=ADALL,Number=R,Type=Integer,Description="Net allele depths across all datasets">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Net allele depths across all unfiltered datasets with called genotype">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Consensus Genotype across all datasets with called genotype">
+##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set in which this variant falls">
+##INFO=<ID=VRS_Allele_IDs,Number=R,Type=String,Description="The computed identifiers for the GA4GH VRS Alleles corresponding to the GT indexes of the REF and ALT alleles">
+##INFO=<ID=VRS_Error,Number=.,Type=String,Description="If an error occurred computing a VRS Identifier, the error message">
+##INFO=<ID=VRS_Starts,Number=R,Type=Integer,Description="Interresidue coordinates used as the location starts for the GA4GH VRS Alleles corresponding to the GT indexes of the REF and ALT alleles">
+##INFO=<ID=VRS_Ends,Number=R,Type=Integer,Description="Interresidue coordinates used as the location ends for the GA4GH VRS Alleles corresponding to the GT indexes of the REF and ALT alleles">
+##INFO=<ID=VRS_States,Number=R,Type=String,Description="The literal sequence states used for the GA4GH VRS Alleles corresponding to the GT indexes of the REF and ALT alleles">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG001
+chr1	783006	.	A	G	50	PASS	platforms=4;platformnames=PacBio,Illumina,10X,CG;datasets=4;datasetnames=CCS15kb_20kb,HiSeqPE300x,10XChromiumLR,CGnormal;callsets=6;callsetnames=CCS15kb_20kbDV,CCS15kb_20kbGATK4,HiSeqPE300xGATK,10XLRGATK,CGnormal,HiSeqPE300xfreebayes;datasetsmissingcall=IonExome,SolidSE75bp;callable=CS_CCS15kb_20kbDV_callable,CS_CCS15kb_20kbGATK4_callable;filt=CS_CGnormal_filt;difficultregion=HG001.hg38.300x.bam.bilkentuniv.010920.dups,hg38.segdups_sorted_merged,lowmappabilityall;VRS_Allele_IDs=ga4gh:VA.dwwiZdvVtfAmomu0OBsiHue1O-bw5SpG,ga4gh:VA.MiasxyXMXtOpsZgGelL3c4QgtflCNLHD;VRS_Starts=783005,783005;VRS_Ends=783006,783006;VRS_States=A,G	GT:PS:DP:ADALL:AD:GQ	1/1:.:652:16,234:0,82:312
+chr1	783175	.	T	C	50	PASS	platforms=4;platformnames=PacBio,Illumina,10X,Solid;datasets=4;datasetnames=CCS15kb_20kb,HiSeqPE300x,10XChromiumLR,SolidSE75bp;callsets=6;callsetnames=CCS15kb_20kbDV,CCS15kb_20kbGATK4,HiSeqPE300xGATK,10XLRGATK,HiSeqPE300xfreebayes,SolidSE75GATKHC;datasetsmissingcall=CGnormal,IonExome;callable=CS_CCS15kb_20kbDV_callable,CS_CCS15kb_20kbGATK4_callable;difficultregion=HG001.hg38.300x.bam.bilkentuniv.010920.dups,hg38.segdups_sorted_merged;VRS_Allele_IDs=ga4gh:VA.5cY2k53xdW7WeHw2WG1HA7jl50iH-r9p,ga4gh:VA.jHaXepIvlbnapfPtH_62y-Qm81hCrBYn;VRS_Starts=783174,783174;VRS_Ends=783175,783175;VRS_States=T,C	GT:PS:DP:ADALL:AD:GQ	1/1:.:639:0,218:0,84:194
+chr1	784860	.	T	C	50	PASS	platforms=4;platformnames=PacBio,Illumina,10X,CG;datasets=4;datasetnames=CCS15kb_20kb,HiSeqPE300x,10XChromiumLR,CGnormal;callsets=6;callsetnames=CCS15kb_20kbDV,CCS15kb_20kbGATK4,HiSeqPE300xGATK,10XLRGATK,CGnormal,HiSeqPE300xfreebayes;datasetsmissingcall=IonExome,SolidSE75bp;callable=CS_CCS15kb_20kbDV_callable,CS_CCS15kb_20kbGATK4_callable;filt=CS_CGnormal_filt;difficultregion=HG001.hg38.300x.bam.bilkentuniv.010920.dups,hg38.segdups_sorted_merged,lowmappabilityall;VRS_Allele_IDs=ga4gh:VA.-NGsjBEx0UbPF3uYjStZ_2r-m2LbUtUB,ga4gh:VA.HLinVo6Q-i-PryQOiq8QAtOeC9oQ9Q3p;VRS_Starts=784859,784859;VRS_Ends=784860,784860;VRS_States=T,C	GT:PS:DP:ADALL:AD:GQ	1/1:.:901:105,406:0,74:301
+chr1	785417	.	G	A	50	PASS	platforms=4;platformnames=PacBio,Illumina,10X,CG;datasets=4;datasetnames=CCS15kb_20kb,HiSeqPE300x,10XChromiumLR,CGnormal;callsets=6;callsetnames=CCS15kb_20kbDV,CCS15kb_20kbGATK4,HiSeqPE300xGATK,10XLRGATK,CGnormal,HiSeqPE300xfreebayes;datasetsmissingcall=IonExome,SolidSE75bp;callable=CS_CCS15kb_20kbDV_callable,CS_CCS15kb_20kbGATK4_callable;filt=CS_CGnormal_filt;difficultregion=HG001.hg38.300x.bam.bilkentuniv.010920.dups,hg38.segdups_sorted_merged,lowmappabilityall;VRS_Allele_IDs=ga4gh:VA.qdyeeiC3cLfXeT23zxT9-qlJNN64MKVB,ga4gh:VA.cNWXR3OLq9D3L19vQFvbHw-aH0vlA5cN;VRS_Starts=785416,785416;VRS_Ends=785417,785417;VRS_States=G,A	GT:PS:DP:ADALL:AD:GQ	1/1:.:820:125,383:0,70:339
+chr1	797392	.	G	A	50	PASS	platforms=3;platformnames=PacBio,Illumina,10X;datasets=3;datasetnames=CCS15kb_20kb,HiSeqPE300x,10XChromiumLR;callsets=5;callsetnames=CCS15kb_20kbDV,CCS15kb_20kbGATK4,HiSeqPE300xGATK,10XLRGATK,HiSeqPE300xfreebayes;datasetsmissingcall=CGnormal,IonExome,SolidSE75bp;callable=CS_CCS15kb_20kbDV_callable,CS_CCS15kb_20kbGATK4_callable;filt=CS_10XLRGATK_filt,CS_CCS15kb_20kbGATK4_filt;difficultregion=HG001.hg38.300x.bam.bilkentuniv.010920.dups,hg38.segdups_sorted_merged,lowmappabilityall;VRS_Allele_IDs=ga4gh:VA.DVMcfA37Llc9QUOA0XfLJbJ-agKyGpGo,ga4gh:VA.OTiBHLE2WW93M4-4zGVrWSqP2GBj8-qM;VRS_Starts=797391,797391;VRS_Ends=797392,797392;VRS_States=G,A	GT:PS:DP:ADALL:AD:GQ	0/1:.:760:161,142:25,37:147

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -14,8 +14,33 @@ def temp_dir() -> Generator:
         yield Path(temp_dir)
 
 
+@pytest.fixture
+def expected_results() -> list[tuple[int, str, str, int, int, int, str, int]]:
+    return [
+        (1, "dwwiZdvVtfAmomu0OBsiHue1O-bw5SpG", "chr1", 783006, 783005, 783006, "A", 1),
+        (2, "MiasxyXMXtOpsZgGelL3c4QgtflCNLHD", "chr1", 783006, 783005, 783006, "G", 1),
+        (3, "5cY2k53xdW7WeHw2WG1HA7jl50iH-r9p", "chr1", 783175, 783174, 783175, "T", 1),
+        (4, "jHaXepIvlbnapfPtH_62y-Qm81hCrBYn", "chr1", 783175, 783174, 783175, "C", 1),
+        (5, "-NGsjBEx0UbPF3uYjStZ_2r-m2LbUtUB", "chr1", 784860, 784859, 784860, "T", 1),
+        (6, "HLinVo6Q-i-PryQOiq8QAtOeC9oQ9Q3p", "chr1", 784860, 784859, 784860, "C", 1),
+        (7, "qdyeeiC3cLfXeT23zxT9-qlJNN64MKVB", "chr1", 785417, 785416, 785417, "G", 1),
+        (8, "cNWXR3OLq9D3L19vQFvbHw-aH0vlA5cN", "chr1", 785417, 785416, 785417, "A", 1),
+        (9, "DVMcfA37Llc9QUOA0XfLJbJ-agKyGpGo", "chr1", 797392, 797391, 797392, "G", 1),
+        (
+            10,
+            "OTiBHLE2WW93M4-4zGVrWSqP2GBj8-qM",
+            "chr1",
+            797392,
+            797391,
+            797392,
+            "A",
+            1,
+        ),
+    ]
+
+
 @pytest.mark.parametrize("input_filename", ["input.vcf", "input.vcf.gz"])
-def test_load(fixture_dir: Path, temp_dir: Path, input_filename: str):
+def test_load(fixture_dir: Path, temp_dir: Path, input_filename: str, expected_results):
     input_file = fixture_dir / input_filename
     temp_db = temp_dir / "tmp.db"
     load.load_vcf(input_file, temp_db)
@@ -23,22 +48,11 @@ def test_load(fixture_dir: Path, temp_dir: Path, input_filename: str):
     conn = sqlite3.connect(temp_db)
     results = conn.execute("SELECT * FROM vrs_locations").fetchall()
     assert len(results) == 10
-    assert results == [
-        (1, "dwwiZdvVtfAmomu0OBsiHue1O-bw5SpG", "chr1", 783006, 1),
-        (2, "MiasxyXMXtOpsZgGelL3c4QgtflCNLHD", "chr1", 783006, 1),
-        (3, "5cY2k53xdW7WeHw2WG1HA7jl50iH-r9p", "chr1", 783175, 1),
-        (4, "jHaXepIvlbnapfPtH_62y-Qm81hCrBYn", "chr1", 783175, 1),
-        (5, "-NGsjBEx0UbPF3uYjStZ_2r-m2LbUtUB", "chr1", 784860, 1),
-        (6, "HLinVo6Q-i-PryQOiq8QAtOeC9oQ9Q3p", "chr1", 784860, 1),
-        (7, "qdyeeiC3cLfXeT23zxT9-qlJNN64MKVB", "chr1", 785417, 1),
-        (8, "cNWXR3OLq9D3L19vQFvbHw-aH0vlA5cN", "chr1", 785417, 1),
-        (9, "DVMcfA37Llc9QUOA0XfLJbJ-agKyGpGo", "chr1", 797392, 1),
-        (10, "OTiBHLE2WW93M4-4zGVrWSqP2GBj8-qM", "chr1", 797392, 1),
-    ]
+    assert results == expected_results
     conn.close()
 
 
-def test_load_specify_uri(fixture_dir: Path, temp_dir: Path):
+def test_load_specify_uri(fixture_dir: Path, temp_dir: Path, expected_results):
     input_file = fixture_dir / "input.vcf"
     temp_db = temp_dir / "tmp.db"
     input_uri = "gs://my/input/file.vcf"
@@ -47,18 +61,7 @@ def test_load_specify_uri(fixture_dir: Path, temp_dir: Path):
     conn = sqlite3.connect(temp_db)
     results = conn.execute("SELECT * FROM vrs_locations").fetchall()
     assert len(results) == 10
-    assert results == [
-        (1, "dwwiZdvVtfAmomu0OBsiHue1O-bw5SpG", "chr1", 783006, 1),
-        (2, "MiasxyXMXtOpsZgGelL3c4QgtflCNLHD", "chr1", 783006, 1),
-        (3, "5cY2k53xdW7WeHw2WG1HA7jl50iH-r9p", "chr1", 783175, 1),
-        (4, "jHaXepIvlbnapfPtH_62y-Qm81hCrBYn", "chr1", 783175, 1),
-        (5, "-NGsjBEx0UbPF3uYjStZ_2r-m2LbUtUB", "chr1", 784860, 1),
-        (6, "HLinVo6Q-i-PryQOiq8QAtOeC9oQ9Q3p", "chr1", 784860, 1),
-        (7, "qdyeeiC3cLfXeT23zxT9-qlJNN64MKVB", "chr1", 785417, 1),
-        (8, "cNWXR3OLq9D3L19vQFvbHw-aH0vlA5cN", "chr1", 785417, 1),
-        (9, "DVMcfA37Llc9QUOA0XfLJbJ-agKyGpGo", "chr1", 797392, 1),
-        (10, "OTiBHLE2WW93M4-4zGVrWSqP2GBj8-qM", "chr1", 797392, 1),
-    ]
+    assert results == expected_results
 
     results = conn.execute("SELECT * FROM file_uris").fetchall()
     assert len(results) == 1

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -112,3 +112,15 @@ def test_load_redundant_rows(fixture_dir: Path, temp_dir: Path):
     conn = sqlite3.connect(temp_db)
     results = conn.execute("SELECT * FROM vrs_locations").fetchall()
     assert len(results) == 10
+
+
+def test_int_position(fixture_dir: Path, temp_dir: Path):
+    """With VRS-Python 2.x, vrs start/end are now Integer. The ingester routine should
+    be resilient to this change.
+    """
+    input_vcf = fixture_dir / "input_positions_ints.vcf"
+    temp_db = temp_dir / "tmp.db"
+    load.load_vcf(input_vcf, temp_db)
+    conn = sqlite3.connect(temp_db)
+    results = conn.execute("SELECT * FROM vrs_locations").fetchall()
+    assert len(results) == 10


### PR DESCRIPTION
close #32 . Adds columns for VRS start/end and allele state.

* Played around with some small tricks to reduce size on disk and it didn't have a significant effect so didn't bother w/ them. I don't love how big this makes things, but I don't have any better ideas yet
* In refactoring the VCF parsing, do some initial work on #36 to handle both `String` and `Integer` coordinates. I pushed a VRS-Python fix last week to move from the former to the latter but any existing annotations will still have the former

the tests have some basic examples of what a row in the main table looks like:

```
        (1, "dwwiZdvVtfAmomu0OBsiHue1O-bw5SpG", "chr1", 783006, 783005, 783006, "A", 1),
```

this is the row ID, VRS ID, raw `CHR` value, `POS` value, VRS start coordinate, VRS end coordinate, VRS allele state, and then a FK out to the URI for the original VCF