### PR TITLE
feat: declare version + provide in CLI

### DIFF
--- a/src/vrsix/__init__.py
+++ b/src/vrsix/__init__.py
@@ -1,1 +1,10 @@
 """Tools for constructing and interacting with sqlite-based indexing of VRS-annotated VCFs."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("thera-py")
+except PackageNotFoundError:
+    __version__ = "unknown"
+finally:
+    del version, PackageNotFoundError

--- a/src/vrsix/__init__.py
+++ b/src/vrsix/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("thera-py")
+    __version__ = version("vrsix")
 except PackageNotFoundError:
     __version__ = "unknown"
 finally:

--- a/src/vrsix/cli.py
+++ b/src/vrsix/cli.py
@@ -6,6 +6,7 @@ from timeit import default_timer as timer
 
 import click
 
+from vrsix import __version__
 from vrsix import load as load_vcf
 
 _logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ def _configure_logging() -> None:
 
 
 @click.group()
+@click.version_option(__version__)
 def cli() -> None:
     """Index VRS-annotated VCFs"""
     _configure_logging()


### PR DESCRIPTION
This is some pretty standard boilerplate that makes the library version importable, and also accessible from the CLI (via `vrsix --version`).